### PR TITLE
Close #2

### DIFF
--- a/example/app.config.js
+++ b/example/app.config.js
@@ -35,7 +35,7 @@ export default {
       "expo-build-properties",
       {
         ios: {
-          deploymentTarget: "16.2",
+          deploymentTarget: "14.0",
         },
       },
     ],


### PR DESCRIPTION
I found this too aggressive. I think 14 is fine, and Swift already checks if iOS 16 is available for the APIs needed.