### PR TITLE
Fix multi-extension entitlements

### DIFF
--- a/plugin/src/withConfig.ts
+++ b/plugin/src/withConfig.ts
@@ -25,12 +25,12 @@ export const withConfig: ConfigPlugin<{
             ios: {
               ...config.extra?.eas?.build?.experimental?.ios,
               appExtensions: [
-                ...(config.extra?.eas?.build?.experimental?.ios
-                  ?.appExtensions ?? []),
                 {
                   targetName,
                   bundleIdentifier,
                 },
+                ...(config.extra?.eas?.build?.experimental?.ios
+                  ?.appExtensions ?? []),
               ],
             },
           },


### PR DESCRIPTION
This PR fixes an issue where the entitlements for a pre-existing extension are overwritten.

Since the `configIndex` is set to 0 before writing the entitlements, we need to make sure we add the new extension at index 0, not to the end of the list.