### PR TITLE
Link otherFiles with the widget target

### DIFF
--- a/plugin/src/xcode/addBuildPhases.ts
+++ b/plugin/src/xcode/addBuildPhases.ts
@@ -31,11 +31,12 @@ export function addBuildPhases(
     assetDirectories,
     entitlementFiles,
     plistFiles,
+    otherFiles
   } = widgetFiles;
 
   // Sources build phase
   xcodeProject.addBuildPhase(
-    [...swiftFiles, ...intentFiles],
+    [...swiftFiles, ...intentFiles, ...otherFiles],
     "PBXSourcesBuildPhase",
     groupName,
     targetUuid,


### PR DESCRIPTION
I need to add custom fonts to the widget so I can use them, simply putting the font files into the `/widgets` folder adds them, but they are not linked with the widget target, so can't be used. This change seems to do it.