### PR TITLE
fix: handle EISDIR error when copying files and directories

### DIFF
--- a/plugin/src/lib/getWidgetFiles.ts
+++ b/plugin/src/lib/getWidgetFiles.ts
@@ -29,26 +29,36 @@ export function getWidgetFiles(
     fs.mkdirSync(targetPath, { recursive: true });
   }
 
+  if (!fs.existsSync(widgetsPath)) {
+    console.error(`Widgets path ${widgetsPath} does not exist`);
+    return widgetFiles;
+  }
+
   if (fs.lstatSync(widgetsPath).isDirectory()) {
     const files = fs.readdirSync(widgetsPath);
-
     files.forEach((file) => {
+      const sourcePath = path.join(widgetsPath, file);
+      const stats = fs.lstatSync(sourcePath);
       const fileExtension = file.split(".").pop();
 
-      if (fileExtension === "swift") {
-        if (file !== moduleFileName) {
-          widgetFiles.swiftFiles.push(file);
-        }
-      } else if (fileExtension === "entitlements") {
-        widgetFiles.entitlementFiles.push(file);
-      } else if (fileExtension === "plist") {
-        widgetFiles.plistFiles.push(file);
-      } else if (fileExtension === "xcassets") {
+      if (stats.isDirectory() && fileExtension === "xcassets") {
         widgetFiles.assetDirectories.push(file);
-      } else if (fileExtension === "intentdefinition") {
-        widgetFiles.intentFiles.push(file);
-      } else {
-        widgetFiles.otherFiles.push(file);
+      } else if (!stats.isDirectory()) {
+        if (fileExtension === "swift") {
+          if (file !== moduleFileName) {
+            widgetFiles.swiftFiles.push(file);
+          }
+        } else if (fileExtension === "entitlements") {
+          widgetFiles.entitlementFiles.push(file);
+        } else if (fileExtension === "plist") {
+          widgetFiles.plistFiles.push(file);
+        } else if (fileExtension === "xcassets") {
+          widgetFiles.assetDirectories.push(file);
+        } else if (fileExtension === "intentdefinition") {
+          widgetFiles.intentFiles.push(file);
+        } else {
+          widgetFiles.otherFiles.push(file);
+        }
       }
     });
   }
@@ -62,54 +72,93 @@ export function getWidgetFiles(
     ...widgetFiles.otherFiles,
   ].forEach((file) => {
     const source = path.join(widgetsPath, file);
-    copyFileSync(source, targetPath);
+    try {
+      copyFileSync(source, targetPath);
+    } catch (error) {
+      console.error(`Error copying file ${file}:`, error);
+    }
   });
 
   // Copy Module.swift and Attributes.swift
   const modulePath = path.join(__dirname, "../../../ios");
-  copyFileSync(
-    path.join(widgetsPath, moduleFileName),
-    path.join(modulePath, "Module.swift")
-  );
-  copyFileSync(
-    path.join(widgetsPath, attributesFileName),
-    path.join(modulePath, "Attributes.swift")
-  );
+  const moduleSource = path.join(widgetsPath, moduleFileName);
+  const attributesSource = path.join(widgetsPath, attributesFileName);
+
+  if (fs.existsSync(moduleSource)) {
+    try {
+      copyFileSync(moduleSource, path.join(modulePath, "Module.swift"));
+    } catch (error) {
+      console.error("Error copying Module.swift:", error);
+    }
+  }
+
+  if (fs.existsSync(attributesSource)) {
+    try {
+      copyFileSync(attributesSource, path.join(modulePath, "Attributes.swift"));
+    } catch (error) {
+      console.error("Error copying Attributes.swift:", error);
+    }
+  }
 
   // Copy directories
   widgetFiles.assetDirectories.forEach((directory) => {
     const imagesXcassetsSource = path.join(widgetsPath, directory);
-    copyFolderRecursiveSync(imagesXcassetsSource, targetPath);
+    try {
+      copyFolderRecursiveSync(imagesXcassetsSource, targetPath);
+    } catch (error) {
+      console.error(`Error copying directory ${directory}:`, error);
+    }
   });
 
   return widgetFiles;
 }
 
 export function copyFileSync(source: string, target: string) {
-  let targetFile = target;
+  if (!fs.existsSync(source)) {
+    throw new Error(`Source file ${source} does not exist`);
+  }
 
+  const sourceStats = fs.lstatSync(source);
+  if (sourceStats.isDirectory()) {
+    throw new Error(`Source ${source} is a directory, expected a file`);
+  }
+
+  let targetFile = target;
   if (fs.existsSync(target) && fs.lstatSync(target).isDirectory()) {
     targetFile = path.join(target, path.basename(source));
   }
 
-  fs.writeFileSync(targetFile, fs.readFileSync(source));
+  try {
+    fs.writeFileSync(targetFile, fs.readFileSync(source));
+  } catch (error) {
+    throw new Error(`Failed to copy ${source} to ${targetFile}: ${error}`);
+  }
 }
 
 function copyFolderRecursiveSync(source: string, target: string) {
+  if (!fs.existsSync(source)) {
+    throw new Error(`Source directory ${source} does not exist`);
+  }
+
+  const sourceStats = fs.lstatSync(source);
+  if (!sourceStats.isDirectory()) {
+    throw new Error(`Source ${source} is not a directory`);
+  }
+
   const targetPath = path.join(target, path.basename(source));
   if (!fs.existsSync(targetPath)) {
     fs.mkdirSync(targetPath, { recursive: true });
   }
 
-  if (fs.lstatSync(source).isDirectory()) {
-    const files = fs.readdirSync(source);
-    files.forEach((file) => {
-      const currentPath = path.join(source, file);
-      if (fs.lstatSync(currentPath).isDirectory()) {
-        copyFolderRecursiveSync(currentPath, targetPath);
-      } else {
-        copyFileSync(currentPath, targetPath);
-      }
-    });
-  }
+  const files = fs.readdirSync(source);
+  files.forEach((file) => {
+    const currentPath = path.join(source, file);
+    const stats = fs.lstatSync(currentPath);
+
+    if (stats.isDirectory()) {
+      copyFolderRecursiveSync(currentPath, targetPath);
+    } else {
+      copyFileSync(currentPath, targetPath);
+    }
+  });
 }


### PR DESCRIPTION
I was having an issue compiling my app and introduced the following features to getWidgetFiles

- Prevents crashes from invalid operations
- Provides clear error messages for debugging
- Handles edge cases properly