### PR TITLE
Fix: Example App Builds

### DIFF
--- a/example/SampleWidgetExtension/Module.swift
+++ b/example/SampleWidgetExtension/Module.swift
@@ -12,7 +12,7 @@ public class ReactNativeWidgetExtensionModule: Module {
         Name("ReactNativeWidgetExtension")
         
         Function("areActivitiesEnabled") { () -> Bool in
-            let logger = Logger()
+            let logger = Logger(logHandlers: [])
             logger.info("areActivitiesEnabled()")
             
             if #available(iOS 16.2, *) {
@@ -23,7 +23,7 @@ public class ReactNativeWidgetExtensionModule: Module {
         }
         
         Function("startActivity") { (quarter: Int, scoreLeft: Int, scoreRight: Int, bottomText: String) -> Void in
-            let logger = Logger()
+            let logger = Logger(logHandlers: [])
             logger.info("startActivity()")
             
             if #available(iOS 16.2, *) {
@@ -43,7 +43,7 @@ public class ReactNativeWidgetExtensionModule: Module {
         }
 
         Function("updateActivity") { (quarter: Int, scoreLeft: Int, scoreRight: Int, bottomText: String) -> Void in
-            let logger = Logger()
+            let logger = Logger(logHandlers: [])
             logger.info("updateActivity()")
             
             if #available(iOS 16.2, *) {
@@ -62,7 +62,7 @@ public class ReactNativeWidgetExtensionModule: Module {
         }
         
         Function("endActivity") { (quarter: Int, scoreLeft: Int, scoreRight: Int, bottomText: String) -> Void in
-            let logger = Logger()
+            let logger = Logger(logHandlers: [])
             logger.info("endActivity()")
             
             if #available(iOS 16.2, *) {


### PR DESCRIPTION

Update Logger Initialization to Fix iOS Build Break in Example App

Description

Recent changes in the Expo Modules Core have updated the Logger API. The previous usage of Logger() without any parameters now fails because the initializer requires a logHandlers parameter. This change is causing iOS native builds to break.

the updated API here:
[Logger.swift Source](https://github.com/expo/expo/blob/499acd3616a5704a76c80b141404d2c9100d553c/packages/expo-modules-core/ios/Core/Logging/Logger.swift#L13)

I couldn't find it in the expo docs   🤷‍♂️

Changes
	•	Logger Initialization:
Updated all instances of Logger() to use Logger(logHandlers: []) to comply with the new API requirements.
