### PR TITLE
Sentry patch cleanup

### DIFF
--- a/plugin/src/withPodfile.ts
+++ b/plugin/src/withPodfile.ts
@@ -1,4 +1,3 @@
-import { mergeContents } from "@expo/config-plugins/build/utils/generateCode";
 import { ConfigPlugin, withDangerousMod } from "@expo/config-plugins";
 import * as fs from "fs";
 import * as path from "path";
@@ -29,22 +28,6 @@ export const withPodfile: ConfigPlugin<{ targetName: string }> = (
         /use_expo_modules!/,
         `use_expo_modules!(searchPaths: ["./node_modules", "../../node_modules", "../../../WidgetExtension"])`
       ); */
-
-      podFileContent = mergeContents({
-        tag: "react-native-widget-extension-1",
-        src: podFileContent,
-        newSrc: `
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        # Sentry has build errors unless configured as 'YES' for the Sentry target: https://github.com/bndkt/react-native-widget-extension/issues/24
-        config.build_settings['APPLICATION_EXTENSION_API_ONLY'] = target.name == 'Sentry' ? 'YES' : 'No'
-      end
-    end
-`,
-        anchor: /:ccache_enabled => podfile_properties\['apple\.ccacheEnabled'\] == 'true',/,
-        offset: 2,
-        comment: "#",
-      }).contents;
 
       /* podFileContent = mergeContents({
         tag: "react-native-widget-extension-2",


### PR DESCRIPTION
Previous implementation of `APPLICATION_EXTENSION_API_ONLY` is no longer necessary according to [this thread](https://github.com/getsentry/sentry-react-native/issues/5099).

Additionally, I've removed the entire `mergeContents` since the default should be NO in the first place.